### PR TITLE
Fixes bug not updating results when using same variables with same query

### DIFF
--- a/packages/mixins/apollo-query-mixin.js
+++ b/packages/mixins/apollo-query-mixin.js
@@ -116,16 +116,14 @@ export const ApolloQueryMixin = superclass => class extends ApolloElementMixin(s
   }
 
   /**
-   * Exposes the [`ObservableQuery#setVariables`](https://www.apollographql.com/docs/react/api/apollo-client.html#ObservableQuery.setVariables) method.
+   * Exposes the [`ObservableQuery#refetch`](https://www.apollographql.com/docs/react/api/apollo-client.html#ObservableQuery.refetch) method.
    * @param {Object}   variables      The new set of variables. If there are missing variables, the previous values of those variables will be used.
-   * @param {boolean=} tryFetch       Try and fetch new results even if the variables haven't changed (we may still just hit the store, but if there's nothing in there will refetch).
-   * @param {boolean=} fetchResults   Option to ignore fetching results when updating variables.
    * @return {Promise<ApolloQueryResult>}
    */
-  setVariables(variables, tryFetch = this.tryFetch, fetchResults = this.fetchResults) {
+  setVariables(variables) {
     return (
       this.observableQuery &&
-      this.observableQuery.setVariables(variables, tryFetch, fetchResults)
+      this.observableQuery.refetch(variables)
     );
   }
 

--- a/packages/mixins/apollo-query-mixin.test.js
+++ b/packages/mixins/apollo-query-mixin.test.js
@@ -119,13 +119,13 @@ describe('ApolloQueryMixin', function describeApolloQueryMixin() {
       expect(el.variables).to.deep.equal({ errorPolicy: 'foo' });
     });
 
-    it('calls observableQuery.subscribe when there is a query', async function setVariablesCallsObservableQuerySetVariables() {
+    it('calls observableQuery.subscribe when there is a query', async function setVariablesCallsObservableQueryRefetch() {
       const query = gql`query { foo }`;
       const el = await getElement({ client, query });
-      const setVariablesSpy = stub(el.observableQuery, 'setVariables');
+      const refetchSpy = stub(el.observableQuery, 'refetch');
       // shouldn't this be an instance of ObservableQuery?
       el.variables = { errorPolicy: 'foo' };
-      expect(setVariablesSpy).to.have.been.calledWith({ errorPolicy: 'foo' });
+      expect(refetchSpy).to.have.been.calledWith({ errorPolicy: 'foo' });
     });
   });
 


### PR DESCRIPTION
Fixes #27 

Stop using setVariables to fetch new results on a query when updating variables and use refetch as recommend by the apollo client docs.