### PR TITLE
Remove bubbles: true and composed: true

### DIFF
--- a/packages/polymer/notifying-element-mixin.js
+++ b/packages/polymer/notifying-element-mixin.js
@@ -18,8 +18,6 @@ export const NotifyingElementMixin = superclass => class extends superclass {
   notify(propName, value) {
     this.dispatchEvent(
       new CustomEvent(`${propName}-changed`, {
-        bubbles: true,
-        composed: true,
         detail: { value },
       })
     );


### PR DESCRIPTION
Doesn't use `bubbles: true` and `composed: true` for `{property-name}-changed` events, as Polymer do.