### PR TITLE
Hotfix/interfaces/npm files

### DIFF
--- a/packages/components/apollo-mutation.ts
+++ b/packages/components/apollo-mutation.ts
@@ -5,7 +5,6 @@ import type { TemplateResult } from 'lit-element';
 import type {
   ApolloMutationInterface,
   Data,
-  RefetchQueriesType,
   Variables,
   VariablesOf,
 } from '@apollo-elements/interfaces';

--- a/packages/fast/custom-elements-manifest.json
+++ b/packages/fast/custom-elements-manifest.json
@@ -83,7 +83,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/fast/package.json
+++ b/packages/fast/package.json
@@ -63,6 +63,7 @@
   },
   "homepage": "https://apolloelements.dev/modules/_apollo_elements_fast.html",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/mixins": "^3.4.1",
     "@microsoft/fast-element": "^0.18.0",
     "tslib": "^2.0.3"

--- a/packages/gluon/custom-elements-manifest.json
+++ b/packages/gluon/custom-elements-manifest.json
@@ -83,7 +83,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/gluon/package.json
+++ b/packages/gluon/package.json
@@ -62,6 +62,7 @@
   },
   "homepage": "https://apolloelements.dev/modules/_apollo_elements_gluon.html",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/mixins": "^3.4.1",
     "@gluon/gluon": ">= 2",
     "tslib": "^2.0.3"

--- a/packages/haunted/package.json
+++ b/packages/haunted/package.json
@@ -57,6 +57,7 @@
   "license": "ISC",
   "homepage": "https://apolloelements.dev/modules/_apollo_elements_haunted.html",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/lib": "^4.0.1",
     "@apollo-elements/mixins": "^3.4.1",
     "haunted": "^4.7.1",

--- a/packages/hybrids/package.json
+++ b/packages/hybrids/package.json
@@ -57,6 +57,7 @@
   "license": "ISC",
   "homepage": "https://apolloelements.dev/modules/_apollo_elements_hybrids.html",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/lib": "^4.0.1",
     "@apollo-elements/mixins": "^3.4.1",
     "hybrids": ">= 2",

--- a/packages/interfaces/custom-elements-manifest.json
+++ b/packages/interfaces/custom-elements-manifest.json
@@ -93,7 +93,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -22,11 +22,11 @@
   },
   "files": [
     "*.d.ts",
-    "*.d.ts",
-    "*.d.ts",
+    "*.js",
+    "*.js.map",
     "**/*.d.ts",
-    "**/*.d.ts",
-    "**/*.d.ts"
+    "**/*.js",
+    "**/*.js.map"
   ],
   "scripts": {
     "prepublishOnly": "tsc -b .",
@@ -46,12 +46,7 @@
     "url": "git+ssh://git@github.com/apollo-elements/apollo-elements.git",
     "directory": "packages/interfaces"
   },
-  "keywords": [
-    "Apollo",
-    "GraphQL",
-    "Web Components",
-    "Custom Elements"
-  ],
+  "keywords": ["Apollo", "GraphQL", "Web Components", "Custom Elements"],
   "author": "Benny Powers <web@bennypowers.com>",
   "license": "ISC",
   "bugs": {

--- a/packages/lit-apollo/apollo-element.ts
+++ b/packages/lit-apollo/apollo-element.ts
@@ -1,11 +1,6 @@
 import type { ApolloError, OperationVariables } from '@apollo/client/core';
 
-import type {
-  ApolloElementInterface,
-  Constructor,
-  Data,
-  GraphQLError,
-} from '@apollo-elements/interfaces';
+import type { Constructor, Data, GraphQLError } from '@apollo-elements/interfaces';
 
 import { LitElement, property } from 'lit-element';
 

--- a/packages/lit-apollo/apollo-mutation.ts
+++ b/packages/lit-apollo/apollo-mutation.ts
@@ -2,7 +2,6 @@ import type {
   ApolloMutationInterface,
   Constructor,
   RefetchQueriesType,
-  Variables,
 } from '@apollo-elements/interfaces';
 
 import type { OperationVariables } from '@apollo/client/core';

--- a/packages/lit-apollo/apollo-query.ts
+++ b/packages/lit-apollo/apollo-query.ts
@@ -1,9 +1,10 @@
-import { NetworkStatus, OperationVariables } from '@apollo/client/core';
+import type { ApolloQueryInterface, Constructor } from '@apollo-elements/interfaces';
+import type { OperationVariables } from '@apollo/client/core';
+import { NetworkStatus } from '@apollo/client/core';
 
 import { property } from 'lit-element';
 
 import { ApolloQueryMixin } from '@apollo-elements/mixins/apollo-query-mixin';
-import { ApolloQueryInterface, Constructor } from '@apollo-elements/interfaces';
 
 import { ApolloElement } from './apollo-element';
 

--- a/packages/lit-apollo/apollo-subscription.ts
+++ b/packages/lit-apollo/apollo-subscription.ts
@@ -1,7 +1,7 @@
 import type { OperationVariables } from '@apollo/client/core';
+import type { ApolloSubscriptionInterface, Constructor } from '@apollo-elements/interfaces';
 
 import { ApolloSubscriptionMixin } from '@apollo-elements/mixins/apollo-subscription-mixin';
-import { ApolloSubscriptionInterface, Constructor } from '@apollo-elements/interfaces';
 
 import { ApolloElement } from './apollo-element';
 

--- a/packages/lit-apollo/custom-elements-manifest.json
+++ b/packages/lit-apollo/custom-elements-manifest.json
@@ -83,7 +83,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/lit-apollo/package.json
+++ b/packages/lit-apollo/package.json
@@ -63,6 +63,7 @@
   },
   "homepage": "https://apolloelements.dev/modules/_apollo_elements_lit_apollo.html",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/mixins": "^3.4.1",
     "lit-element": "^2",
     "lit-html": "^1",

--- a/packages/mixins/apollo-client-mixin.ts
+++ b/packages/mixins/apollo-client-mixin.ts
@@ -1,5 +1,9 @@
-import { ApolloElementInterface, CustomElement, Constructor } from '@apollo-elements/interfaces';
-import { ApolloClient, NormalizedCacheObject } from '@apollo/client/core';
+import type { ApolloClient, NormalizedCacheObject } from '@apollo/client/core';
+import type {
+  ApolloElementInterface,
+  CustomElement,
+  Constructor,
+} from '@apollo-elements/interfaces';
 
 export function ApolloClientMixin<B extends Constructor<ApolloElementInterface & CustomElement>>(
   client: ApolloClient<NormalizedCacheObject>,

--- a/packages/mixins/apollo-element-mixin.ts
+++ b/packages/mixins/apollo-element-mixin.ts
@@ -6,14 +6,13 @@ import type {
   OperationVariables,
 } from '@apollo/client/core';
 
-import type { GraphQLError } from '@apollo-elements/interfaces';
-
 import type {
   ApolloElementElement,
   ApolloElementInterface,
   ComponentDocument,
   Constructor,
   Data,
+  GraphQLError,
   Variables,
 } from '@apollo-elements/interfaces';
 

--- a/packages/mixins/custom-elements-manifest.json
+++ b/packages/mixins/custom-elements-manifest.json
@@ -83,7 +83,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/polymer/apollo-element.ts
+++ b/packages/polymer/apollo-element.ts
@@ -5,8 +5,12 @@ import type {
   OperationVariables,
 } from '@apollo/client/core';
 
-import type { ApolloElementInterface, Data, Variables } from '@apollo-elements/interfaces';
-import type { GraphQLError } from '@apollo-elements/interfaces';
+import type {
+  ApolloElementInterface,
+  Data,
+  GraphQLError,
+  Variables,
+} from '@apollo-elements/interfaces';
 
 import { notify, PolymerChangeEvent } from './notify-decorator';
 import { ApolloElementMixin } from '@apollo-elements/mixins/apollo-element-mixin';

--- a/packages/polymer/apollo-subscription.ts
+++ b/packages/polymer/apollo-subscription.ts
@@ -1,5 +1,5 @@
 import type { OperationVariables } from '@apollo/client/core';
-import { ApolloSubscriptionInterface, Constructor } from '@apollo-elements/interfaces';
+import type { ApolloSubscriptionInterface, Constructor } from '@apollo-elements/interfaces';
 import { ApolloSubscriptionMixin } from '../mixins/apollo-subscription-mixin';
 import { PolymerApolloElement } from './apollo-element';
 

--- a/packages/polymer/custom-elements-manifest.json
+++ b/packages/polymer/custom-elements-manifest.json
@@ -115,7 +115,8 @@
             {
               "kind": "field",
               "name": "document",
-              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM).",
+              "summary": "Internal property corresponding to `query`, `mutation`, or `subscription`. Use those instead.",
+              "description": "A GraphQL document containing a single query, mutation, or subscription. You can set it as a JavaScript property or by appending a GraphQL script to the element (light DOM). The `document` property should be considered internal and its use avoided.",
               "type": {
                 "type": "DocumentNode | TypedDocumentNode | null",
                 "references": [

--- a/packages/polymer/package.json
+++ b/packages/polymer/package.json
@@ -61,6 +61,7 @@
   },
   "homepage": "https://apolloelements.dev/api/libraries/polymer/",
   "dependencies": {
+    "@apollo-elements/interfaces": "^1.4.1",
     "@apollo-elements/mixins": "^3.4.1",
     "tslib": "^2.0.3"
   }


### PR DESCRIPTION
adds `@apollo-elements/interfaces` as a hard dependency for all packages

- even packages that only `import type { ... } from @apollo-elements/interfaces` 
- `@apollo-elements/interfaces` is negligible as far as bundle size goes, and including it will prevent problems with tools like snowpack and webcomponents.dev