### PR TITLE
Fix generator for Windows users

### DIFF
--- a/.changeset/silent-plants-glow.md
+++ b/.changeset/silent-plants-glow.md
@@ -1,0 +1,5 @@
+---
+"@apollo-elements/create": patch
+---
+
+Fixes for Windows users

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,5 +1,7 @@
 exclude_patterns:
-  - karma.conf.js
   - packages/**/*.test.ts
   - packages/**/*.d.ts
+  - test/**/*.test.ts
+  - test/schema.ts
+  - test/helpers.ts
   - '**/node_modules/**/*'

--- a/docs/api/core/controllers/mutation.md
+++ b/docs/api/core/controllers/mutation.md
@@ -24,6 +24,7 @@ Apollo Elements controllers are not limited to Lit. Use them with any object tha
 </inline-notification>
 
 ```ts playground mutation-controller add-user.ts
+import '@apollo-elements/components/apollo-client';
 import { ApolloMutationController } from '@apollo-elements/core';
 import { customElement, state, query } from 'lit/decorators.js';
 import { css, html, LitElement } from 'lit';
@@ -77,7 +78,6 @@ mutation AddUser($name: String) {
 import { ApolloClient, InMemoryCache } from '@apollo/client/core';
 import { SchemaLink } from '@apollo/client/link/schema';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { EventIterator } from 'event-iterator';
 
 const USERS = [ ];
 

--- a/docs/api/core/controllers/query.md
+++ b/docs/api/core/controllers/query.md
@@ -24,6 +24,7 @@ Apollo Elements controllers are not limited to Lit. Use them with any object tha
 </inline-notification>
 
 ```ts playground query-controller profile-home.ts
+import '@apollo-elements/components/apollo-client';
 import { ApolloQueryController } from '@apollo-elements/core';
 import { customElement } from 'lit/decorators.js';
 import { html, LitElement } from 'lit';

--- a/packages/create/app.ts
+++ b/packages/create/app.ts
@@ -28,7 +28,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  */
 async function initFiles(options: AppOptions) {
   console.log(`\n${cyan('Scaffolding App Files')}...\n`);
-  const templatePath = path.resolve(__dirname, 'template/app');
+  const templatePath = path.resolve(__dirname, 'template', 'app');
   await ncp(templatePath, cwd);
   await rename(path.join(cwd, '__gitignore'), path.join(cwd, '.gitignore'));
 
@@ -40,7 +40,7 @@ async function initFiles(options: AppOptions) {
 
   const FILE_NAMES = {
     rc: '.graphqlrc.yml',
-    client: 'src/client.ts',
+    client: path.join('src', 'client.ts'),
   };
 
   async function write(key: keyof typeof FILE_NAMES) {

--- a/packages/create/bin/hack.js
+++ b/packages/create/bin/hack.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import fs from 'fs/promises';
+import path from 'path';
+
+const index = new URL(path.join('..', 'index.js'), import.meta.url);
+
+async function exists(x) {
+  try {
+    await fs.access(x, fs.constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * ```bash
+ * [ -s index.js ]
+ * ```
+ */
+async function dashEss(x) {
+  try {
+    const { size } = await fs.stat(x);
+    return size !== 0;
+  } catch {
+    return false;
+  }
+}
+
+async function rm(p) {
+  try {
+    await fs.rm(p);
+  } catch {}
+}
+
+async function hack() {
+  const command = process.argv.pop();
+  switch (command) {
+    case 'pre': return (await exists(index)) || await fs.writeFile(index, '', 'utf-8');
+    case 'post': return (await dashEss(index)) || await rm(index);
+  }
+}
+
+hack();

--- a/packages/create/bin/main.js
+++ b/packages/create/bin/main.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import { main } from '../index.js';
+main();

--- a/packages/create/codegen.ts
+++ b/packages/create/codegen.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import execa, { ExecaReturnValue } from 'execa';
 import { AppOptions, BaseOptions, ComponentOptions } from './options.js';
 import { getOperationFileName, getUnprefixedTagName } from './component.js';
@@ -13,7 +14,12 @@ interface ExecaError {
 
 function getFailedFilename(options: ComponentOptions): string {
   try {
-    return `src/components/${getUnprefixedTagName(options)}/${getOperationFileName(options)}`;
+    return path.join(
+      'src',
+      'components',
+      getUnprefixedTagName(options),
+      getOperationFileName(options)
+    );
   } catch {
     return 'the generated operation file';
   }

--- a/packages/create/component.ts
+++ b/packages/create/component.ts
@@ -66,13 +66,13 @@ const TEMPLATE_BASENAMES: Record<FileKey, string> = {
   index: 'index.ts',
 };
 
-const DEFAULT_QUERY_FIELDS = `# replace with your fields
-__schema {
-  types {
-    name
-    kind
-  }
-}`;
+const DEFAULT_QUERY_FIELDS = `  # replace with your fields
+  __schema {
+    types {
+      name
+      kind
+    }
+  }`;
 
 const DEFAULT_SUBSCRIPTION_FIELDS = DEFAULT_QUERY_FIELDS;
 
@@ -274,7 +274,7 @@ async function shouldWriteToDir(options: ComponentOptions): Promise<boolean> {
 
 async function getTemplate(key: FileKey): Promise<string> {
   const TEMPLATE_DIR =
-    join(__dirname, 'template/component');
+    join(__dirname, 'template', 'component');
 
   return await readFile(join(TEMPLATE_DIR, TEMPLATE_BASENAMES[key]), 'utf8');
 }

--- a/packages/create/index.ts
+++ b/packages/create/index.ts
@@ -1,8 +1,6 @@
-#!/usr/bin/env node
-
 import { prompt } from './prompt.js';
 
-async function main() {
+export async function main(): Promise<void> {
   try {
     await prompt();
   } catch (e) {
@@ -10,4 +8,3 @@ async function main() {
       console.error(e);
   }
 }
-main();

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -5,10 +5,9 @@
   "author": "Benny Powers <web@bennypowers.com>",
   "license": "ISC",
   "type": "module",
-  "main": "./index.js",
-  "typings": ".index.d.ts",
+  "typings": "./index.d.ts",
   "bin": {
-    "create-app": "index.js"
+    "create-app": "bin/main.js"
   },
   "keywords": [
     "generator",
@@ -21,8 +20,8 @@
   ],
   "scripts": {
     "🚨__COMMENT__🚨": "echo 'The next two lines are a workaround for https://github.com/npm/cli/issues/2632'",
-    "preinstall": "touch index.js",
-    "postinstall": "[ -s index.js ] || rm -f index.js",
+    "preinstall": "node bin/hack.js pre",
+    "postinstall": "node bin/hack.js post",
     "prepublishOnly": "tsc -b .",
     "build": "tsc",
     "lint": "run-s lint:*",


### PR DESCRIPTION
- use `path.join` everywhere
- remove workaround for an [npm bug](https://github.com/npm/cli/issues/2632) which assumed a unix environment