### PR TITLE
chore(deps): upgrade @rollup/plugin-commonjs to v29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@open-wc/testing": "^4.0.0",
         "@polymer/polymer": "^3.5.2",
         "@pwrs/cem": "^0.10.6",
-        "@rollup/plugin-commonjs": "^28.0.6",
+        "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-graphql": "^2.0.5",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-typescript": "^12.3.0",
@@ -7269,9 +7269,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
-      "version": "28.0.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
-      "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+      "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -26347,9 +26347,9 @@
       "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA=="
     },
     "@rollup/plugin-commonjs": {
-      "version": "28.0.6",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.6.tgz",
-      "integrity": "sha512-XSQB1K7FUU5QP+3lOQmVCE3I0FcbbNvmNT4VJSj93iUjayaARrTQeoRdiYQoftAJBLrR9t2agwAd3ekaTgHNlw==",
+      "version": "29.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+      "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@microsoft/fast-components": "^2.30.6",
     "@open-wc/testing": "^4.0.0",
     "@polymer/polymer": "^3.5.2",
-    "@rollup/plugin-commonjs": "^28.0.6",
+    "@rollup/plugin-commonjs": "^29.0.3",
     "@rollup/plugin-graphql": "^2.0.5",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",


### PR DESCRIPTION
## Summary

- Upgrade `@rollup/plugin-commonjs` from ^28.0.6 to ^29.0.3

`@rollup/plugin-graphql` v3 cannot be upgraded yet -- it uses the new Rollup plugin filter API (object-form transform hook) which `@web/dev-server-rollup`'s `fromRollup` adapter does not support.

## Verification

- [x] `npm install` succeeds
- [x] `npm run build` completes
- [x] `npm run lint` passes
- [x] `npm test` passes (1909/1909)

Closes #323