### PR TITLE
fix(core): omit notifyOnNetworkStatusChange from executeQuery

### DIFF
--- a/.changeset/fix-executequery-notify.md
+++ b/.changeset/fix-executequery-notify.md
@@ -1,0 +1,5 @@
+---
+"@apollo-elements/core": patch
+---
+
+Fixed `executeQuery()` throwing under Apollo Client 4 by removing `notifyOnNetworkStatusChange` from `client.query()` options, where it is not supported.

--- a/packages/core/apollo-query-controller.test.ts
+++ b/packages/core/apollo-query-controller.test.ts
@@ -550,6 +550,12 @@ describe('[core] ApolloQueryController', function() {
             });
           });
 
+          it('does not pass notifyOnNetworkStatusChange to client.query()', function() {
+            expect(querySpy.called).to.be.true;
+            expect(querySpy.lastCall.args[0])
+              .to.not.have.property('notifyOnNetworkStatusChange');
+          });
+
           it('refetches and updates state', function() {
             // Apollo Client v4: initial (null+data) + executeQuery (data) = 3 calls
             expect(onDataSpy.callCount).to.equal(3);

--- a/packages/core/apollo-query-controller.ts
+++ b/packages/core/apollo-query-controller.ts
@@ -391,7 +391,6 @@ export class ApolloQueryController<D, V = VariablesOf<D>>
         ...(this.options.context && { context: this.options.context }),
         ...(this.options.errorPolicy && { errorPolicy: this.options.errorPolicy }),
         ...(fetchPolicy && { fetchPolicy }),
-        notifyOnNetworkStatusChange: this.options.notifyOnNetworkStatusChange ?? true,
         ...params,
       });
       if (result) // NB: not sure why, but sometimes this returns undefined


### PR DESCRIPTION
## Summary

- Remove `notifyOnNetworkStatusChange` from `executeQuery()`'s `client.query()` call
- Apollo Client 4 rejects this option on `client.query()` with an InvariantError -- it only applies to `watchQuery()`
- Add regression test verifying the option is not passed

## Context

The 3.0.0 release added `notifyOnNetworkStatusChange: this.options.notifyOnNetworkStatusChange ?? true` to three call sites. Two are correct (`watchQuery()` and `subscribe()` both hit `client.watchQuery()`). The third is in `executeQuery()`, which calls `client.query()` -- where AC4 throws.

Any controller using `noAutoSubscribe` + `executeQuery()` hits this immediately.

## Test plan

- [x] New test asserts `notifyOnNetworkStatusChange` is not a property of `client.query()` args
- [x] All 1910 existing tests pass (0 failures, 1 skipped)

Fixes #334